### PR TITLE
fixed bug in format_tokyo247.py

### DIFF
--- a/format_tokyo247.py
+++ b/format_tokyo247.py
@@ -36,7 +36,7 @@ os.makedirs(join(raw_data_folder, "tokyo247"), exist_ok=True)
 matlab_struct_file_path = join(dataset_folder, 'raw_data', 'datasets', 'tokyo247.mat')
 
 mat_struct = loadmat(matlab_struct_file_path)["dbStruct"].item()
-db_images = [join('tokyo247', f[0].item().replace('.jpg', '.png')) for f in mat_struct[1]]
+db_images = [f[0].item().replace('.jpg', '.png') for f in mat_struct[1]]
 
 db_utms = mat_struct[2].T
 dst_folder = join(dataset_folder, 'images', 'test', 'database')


### PR DESCRIPTION
I replaced all Tokyo24/7 files as in instruction. When I ran `python format_tokyo247.py` this error occurred:
```
Copy to ./datasets/tokyo247/images/test/database:   0%|                   | 0/75984 [00:00<?, ?it/s]Exception [Errno 2] No such file or directory: './datasets/tokyo247/raw_data/tokyo247/03814/381418.231_3946450.428/JHVdmPpMNQcjBfR7qsWEtA_012_000.png' with file ./datasets/tokyo247/raw_data/tokyo247/03814/381418.231_3946450.428/JHVdmPpMNQcjBfR7qsWEtA_012_000.png
Copy to ./datasets/tokyo247/images/test/database:   0%|                   | 0/75984 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "format_tokyo247.py", line 59, in <module>
    raise e
  File "format_tokyo247.py", line 56, in <module>
    Image.open(src_image_path).save(f"{dst_folder}/{dst_image_name}")
  File "/opt/conda/lib/python3.7/site-packages/PIL/Image.py", line 2912, in open
    fp = builtins.open(filename, "rb")
FileNotFoundError: [Errno 2] No such file or directory: './datasets/tokyo247/raw_data/tokyo247/03814/381418.231_3946450.428/JHVdmPpMNQcjBfR7qsWEtA_012_000.png'
```

I fixed this bug